### PR TITLE
honorate database config file infos

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
     "trustProxy": false,
     "topAccounts": false,
     "db": {
+        "install": true,
         "host": "localhost",
         "port": 5432,
         "database": "rise_testnet_db",


### PR DESCRIPTION
*Commit message*: honorate database config file infos  while restoring blockchain or showing block height + Added config.db.install boolean to allow user to install postgres by themselves.
-----

Hello I noticed some `config.json`  _db_ section variables were not taken into account (port and host).

I also added a new config.json variable named `install` within _db_ section. If false the node owner will need to provision its own postgres server by himself.