### PR TITLE
Fix issue 27

### DIFF
--- a/logic/vote.js
+++ b/logic/vote.js
@@ -350,7 +350,7 @@ Vote.prototype.objectNormalize = function (trs) {
 	var report = library.schema.validate(trs.asset, Vote.prototype.schema);
 
 	if (!report) {
-		throw 'Failed to validate vote schema: ' + this.scope.schema.getLastErrors().map(function (err) {
+		throw 'Failed to validate vote schema: ' + library.schema.getLastErrors().map(function (err) {
 			return err.message;
 		}).join(', ');
 	}

--- a/logic/vote.js
+++ b/logic/vote.js
@@ -327,10 +327,15 @@ Vote.prototype.schema = {
 			type: 'array',
 			minItems: 1,
 			maxItems: constants.maxVotesPerTransaction,
-			uniqueItems: true
+			uniqueItems: true,
+      items: {
+        type: 'string',
+        pattern: '^[-+]{1}[0-9a-z]{64}$'
+      }
 		}
 	},
-	required: ['votes']
+	required: ['votes'],
+  "additionalProperties": false
 };
 
 /**


### PR DESCRIPTION
This PR should fix an issue and an improvement in logic/vote schema validation.

The issue is that the path for to access to schema.getLastErrors() was wrong.

The improvements are to improve the validation and integrity for to validate votes values and avoid additional properties in votes schema.